### PR TITLE
feat: Use favicon for project link

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                 <h2 class="text-2xl font-semibold text-center mb-6">Projekte</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                     <a href="https://clipge.com" target="_blank" class="social-link bg-gray-700/50 hover:bg-gray-700 text-white py-4 px-6 rounded-lg flex items-center justify-center space-x-3">
-                        <i class="fas fa-rocket text-2xl"></i>
+                        <img src="https://clipge.com/favicon-32x32.png" alt="clipge.com favicon" class="w-6 h-6">
                         <span class="font-semibold">clipge.com</span>
                     </a>
                 </div>


### PR DESCRIPTION
Updates the project link for clipge.com to use its favicon instead of a generic Font Awesome icon, as requested by the user.