### PR TITLE
feat: Add projects section and display project link

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,10 +95,10 @@
         <section class="w-full max-w-2xl mt-12">
             <div class="bg-slate-800/60 border border-slate-700 backdrop-blur-sm rounded-xl shadow-2xl p-8">
                 <h2 class="text-2xl font-semibold text-center mb-6">Projekte</h2>
-                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                    <a href="https://clipge.com" target="_blank" class="social-link bg-gray-700/50 hover:bg-gray-700 text-white py-4 px-6 rounded-lg flex items-center justify-center space-x-3">
+                <div class="flex flex-col gap-6">
+                    <a href="https://clipge.com" target="_blank" class="social-link bg-gray-700/50 hover:bg-gray-700 text-white py-4 px-6 rounded-lg flex items-center justify-start space-x-3">
                         <img src="clipge-favicon-32x32.png" alt="clipge.com favicon" class="w-6 h-6">
-                        <span class="font-semibold">clipge.com</span>
+                        <span class="font-semibold">Clipge - Discover the Best Twitch Clips</span>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
- Adds a new "Projekte" section to the website to showcase projects.
- Includes the first project, "clipge.com".
- The project is displayed as a full-width button to accommodate a longer description.
- The button uses a local favicon file (`clipge-favicon-32x32.png`) for the project icon.
- The button text is "Clipge - Discover the Best Twitch Clips".